### PR TITLE
Wrap sheetmanger around app and set target to app container

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import {StyleSheetManager} from 'styled-components';
 import {
   Button,
   ThemeProvider,
@@ -34,7 +35,9 @@ export default class MyFirstComponent extends HTMLElement {
     container.appendChild(contentSpan);
 
     const root = createRoot(contentSpan);
-    root.render(<App />);
+    root.render(
+      <StyleSheetManager target={container}><App /></StyleSheetManager>
+    );
     shadow.appendChild(container);
   }
 }


### PR DESCRIPTION
Styled components allow you to target an alternative dom
https://styled-components.com/docs/api#stylesheetmanager

Since the custom html element was initiated prior to rendering of react, the stylesheet manager needs to be initated in the shadow root and target a dom element to wrap everything around

https://github.com/styled-components/styled-components/blob/main/packages/styled-components/src/sheet/Sheet.ts#L15